### PR TITLE
Add SessionFsm::getChannel overload with `waitForReconnect` parameter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,14 +8,14 @@ plugins {
 }
 
 group = "com.digitalpetri.netty"
-version = "0.5"
+version = "0.6-SNAPSHOT"
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    compile("com.digitalpetri.fsm:strict-machine:0.4")
+    api("com.digitalpetri.fsm:strict-machine:0.5")
 
     // BYO SLF4J
     compileOnly("org.slf4j:slf4j-api:1.7.+")
@@ -57,12 +57,12 @@ tasks {
 
 task<Jar>("sourcesJar") {
     from(sourceSets.main.get().allJava)
-    classifier = "sources"
+    archiveClassifier.set("sources")
 }
 
 task<Jar>("javadocJar") {
     from(tasks.javadoc)
-    classifier = "javadoc"
+    archiveClassifier.set("javadoc")
 }
 
 tasks.withType<Jar> {

--- a/src/main/java/com/digitalpetri/netty/fsm/ChannelFsmFactory.java
+++ b/src/main/java/com/digitalpetri/netty/fsm/ChannelFsmFactory.java
@@ -442,9 +442,9 @@ public class ChannelFsmFactory {
                 if (event.waitForReconnect) {
                     handleGetChannelEvent(ctx, config);
                 } else {
-                    config.getExecutor().execute(
-                        () ->
-                            event.channelFuture.completeExceptionally(new Exception("not reconnected"))
+                    config.getExecutor().execute(() ->
+                        event.channelFuture
+                            .completeExceptionally(new Exception("not reconnected"))
                     );
                 }
             });

--- a/src/main/java/com/digitalpetri/netty/fsm/Event.java
+++ b/src/main/java/com/digitalpetri/netty/fsm/Event.java
@@ -90,6 +90,16 @@ public interface Event {
     class GetChannel implements Event {
         final CompletableFuture<Channel> channelFuture = new CompletableFuture<>();
 
+        final boolean waitForReconnect;
+
+        GetChannel() {
+            this(true);
+        }
+
+        GetChannel(boolean waitForReconnect) {
+            this.waitForReconnect = waitForReconnect;
+        }
+
         @Override
         public String toString() {
             return getClass().getSimpleName();

--- a/src/test/java/com/digitalpetri/netty/fsm/ReconnectWaitActions.kt
+++ b/src/test/java/com/digitalpetri/netty/fsm/ReconnectWaitActions.kt
@@ -17,7 +17,6 @@
 package com.digitalpetri.netty.fsm
 
 import com.digitalpetri.netty.fsm.ChannelFsm.*
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -217,6 +216,14 @@ class ReconnectWaitActions {
 
         assertEventualState(fsm, State.ReconnectWait)
 
+        assertWithTimeout {
+            val getChannel = Event.GetChannel(false)
+            fsm.fsm.fireEvent(getChannel)
+
+            assertThrows(Exception::class.java) {
+                getChannel.channelFuture.get()
+            }
+        }
 
         run {
             val getChannel = Event.GetChannel()
@@ -288,5 +295,5 @@ class ReconnectWaitActions {
             assertNull(KEY_RDF.get(ctx))
         }
     }
-    
+
 }


### PR DESCRIPTION
Introduce a new overload that offers control over the behavior of `SessionFsm::getChannel` when the FSM is in the `ReconnectWait` state. When `true`, it behaves the same as the parameterless call and the `CompletableFuture` won't be completed until a connection attempt has been made. When `false`, the returned `CompletableFuture` will have already been completed exceptionally.